### PR TITLE
Update collections

### DIFF
--- a/mycoMINE/plugins/Gazetteer_LKB/creole.xml
+++ b/mycoMINE/plugins/Gazetteer_LKB/creole.xml
@@ -2,7 +2,7 @@
 <CREOLE-DIRECTORY>		     
 	<JAR>lib/commons-cli-1.1.jar</JAR>
 	<JAR>lib/commons-codec-1.3.jar</JAR>
-	<JAR>lib/commons-collections-3.2.1.jar</JAR>
+	<JAR>lib/commons-collections-3.2.2.jar</JAR>
 	<JAR>lib/commons-httpclient-3.1.jar</JAR>
 	<JAR>lib/kim-api-3.0-RC5.jar</JAR>
 	<JAR>lib/kim-util-3.0-RC5.jar</JAR>

--- a/mycoMINE/plugins/Gazetteer_LKB/pom.xml
+++ b/mycoMINE/plugins/Gazetteer_LKB/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Upgrade Apache Commons Collections to v3.2.2

Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
